### PR TITLE
Update to latest mongodb driver and add tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [stable]
+        mongodb-version: [4.2]
 
     steps:
     - uses: actions/checkout@master
+    
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.3.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
 
     - name: Install ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
         rust: [stable]
         mongodb-version: [4.2]
 
@@ -27,7 +27,7 @@ jobs:
       uses: supercharge/mongodb-github-action@1.3.0
       with:
         mongodb-version: ${{ matrix.mongodb-version }}
-
+        
     - name: Install ${{ matrix.rust }}
       uses: actions-rs/toolchain@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ authors = [
 [features]
 
 [dependencies]
-# mongodb = { version = "1.0.0", default-features = false, features = ["async-std-runtime"] }
-mongodb = { git = "https://github.com/saghm/mongo-rust-driver", default-features = false, branch = "RUST-452", features = ["async-std-runtime"] }
+mongodb = { version = "1.1.1", default-features = false, features = ["async-std-runtime"] }
 async-session = "2.0.0"
 async-trait = "0.1.36"
 serde_json = "1.0.56"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }
+rand = {version = "0.7.3"}
+lazy_static = "1"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@
 ```sh
 $ cargo add async-mongodb-session
 ```
+## Test
+
+The tests rely on an running instance of mongodb.
+The quickest way to get an instance up and running locally is using the following docker command:
+
+```
+$ docker run -d -p 27017:27017 -v ~/data:/data/db mongo:4.2
+```
+
+The tests can then be executed with
+```
+$ cargo test
+```
+
+The default settings for the mongodb instance is set to 127.0.0.1:27017 but that can be over ridden by setting the HOST and PORT environment variables.
+```
+$ HOST=mymongo.com PORT=1234 cargo test
+```
 
 ## Safety
 This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ cargo add async-mongodb-session
 ```
 ## Test
 
-The tests rely on an running instance of mongodb.
+The tests rely on an running instance of mongodb either on your local machine or remote.
 The quickest way to get an instance up and running locally is using the following docker command:
 
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,12 @@
 //! # Examples
 //!
 //! ```
-//! // tbi
+//! use async_mongodb_session::*;
+//! use async_session::{Session, SessionStore};
+//!
+//! # fn main() -> async_session::Result { async_std::task::block_on(async {
+//! let store = MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "collection");
+//! # Ok(()) }) }
 //! ```
 
 #![forbid(unsafe_code, future_incompatible, rust_2018_idioms)]
@@ -26,12 +31,38 @@ pub struct MongodbSessionStore {
 
 impl MongodbSessionStore {
     /// Create a new instance of `MongodbSessionStore`.
+    /// ```rust
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// # use async_mongodb_session::MongodbSessionStore;
+    /// let store =
+    /// MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "collection")
+    /// .await?;
+    /// # Ok(()) }) }
+    /// ```
     pub async fn connect(uri: &str, db: &str, coll_name: &str) -> mongodb::error::Result<Self> {
         let client = Client::with_uri_str(uri).await?;
         Ok(Self::from_client(client, db, coll_name))
     }
 
     /// Create a new instance of `MongodbSessionStore` from an open client.
+    /// ```rust
+    /// use mongodb::{options::ClientOptions, Client};
+    ///
+    /// # fn main() -> async_session::Result { async_std::task::block_on(async {
+    /// # use async_mongodb_session::MongodbSessionStore;
+    ///             let client_options = match ClientOptions::parse("mongodb://127.0.0.1:27017").await {
+    ///     Ok(c) => c,
+    ///     Err(e) => panic!("Client Options Failed: {}", e),
+    /// };
+
+    /// let client = match Client::with_options(client_options) {
+    ///     Ok(c) => c,
+    ///     Err(e) => panic!("Client Creation Failed: {}", e),
+    /// };
+
+    /// let store = MongodbSessionStore::from_client(client, "db_name", "collection");
+    /// # Ok(()) }) }
+    /// ```
     pub fn from_client(client: Client, db: &str, coll_name: &str) -> Self {
         Self {
             client,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,1 +1,66 @@
+#[cfg(test)]
+mod tests {
+    use async_mongodb_session::*;
+    use async_session::{Session, SessionStore};
+    use lazy_static::lazy_static;
+    use mongodb::{options::ClientOptions, Client};
+    use rand::Rng;
+    use std::env;
 
+    lazy_static! {
+        static ref HOST: String = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        static ref PORT: String = env::var("PORT").unwrap_or_else(|_| "27017".to_string());
+        static ref CONNECTION_STRING: String =
+            format!("mongodb://{}:{}/", HOST.as_str(), PORT.as_str());
+    }
+
+    #[test]
+    fn test_from_client() -> async_session::Result {
+        async_std::task::block_on(async {
+            let client_options = match ClientOptions::parse(&CONNECTION_STRING).await {
+                Ok(c) => c,
+                Err(e) => panic!("Client Options Failed: {}", e),
+            };
+
+            let client = match Client::with_options(client_options) {
+                Ok(c) => c,
+                Err(e) => panic!("Client Creation Failed: {}", e),
+            };
+
+            let store = MongodbSessionStore::from_client(client, "db_name", "collection");
+            let mut rng = rand::thread_rng();
+            let n2: u16 = rng.gen();
+            let key = format!("key-{}", n2);
+            let value = format!("value-{}", n2);
+            let mut session = Session::new();
+            session.insert(&key, &value)?;
+
+            let cookie_value = store.store_session(session).await?.unwrap();
+            let session = store.load_session(cookie_value).await?.unwrap();
+            assert_eq!(&session.get::<String>(&key).unwrap(), &value);
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_connect() -> async_session::Result {
+        async_std::task::block_on(async {
+            let store =
+                MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
+
+            let mut rng = rand::thread_rng();
+            let n2: u16 = rng.gen();
+            let key = format!("key-{}", n2);
+            let value = format!("value-{}", n2);
+            let mut session = Session::new();
+            session.insert(&key, &value)?;
+
+            let cookie_value = store.store_session(session).await?.unwrap();
+            let session = store.load_session(cookie_value).await?.unwrap();
+            assert_eq!(&session.get::<String>(&key).unwrap(), &value);
+
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
Hey All
std-async 1.6 support has landed in mongodb driver https://github.com/mongodb/mongo-rust-driver/releases/tag/v1.1.1
This PR bumps the dependency in the Cargo.toml and also fixes https://github.com/yoshuawuyts/async-mongodb-session/issues/1 (edit)
It also adds some documentation for the `connect` and `from_client` calls and adds integration tests for them as well.
The integration tests depend on a running mongo instance so I have removed windows and macos from the matrix in the ci.yml action so it could use `supercharge/mongodb-github-action@1.3.0`
There may be a way to do it where it's possible to keep macos and windows but my actions knowledge couldn't stretch to it.

Hope you find this useful.

 

