### PR TITLE
Store as document fix and documentation on how to configure session expiry.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ serde_json = "1.0.56"
 async-std = { version = "1.6.2", features = ["attributes"] }
 rand = {version = "0.7.3"}
 lazy_static = "1"
+tide = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = []
 authors = [
     "Yoshua Wuyts <yoshuawuyts@gmail.com>",
     "Irina Shestak <shestak.irina@gmail.com>",
+    "Anton Whalley <anton@venshare.com>",
 ]
 
 [features]
@@ -21,6 +22,7 @@ mongodb = { version = "1.1.1", default-features = false, features = ["async-std-
 async-session = "2.0.0"
 async-trait = "0.1.36"
 serde_json = "1.0.56"
+chrono = "0.4.19"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1.36"
 serde_json = "1.0.56"
 
 [dev-dependencies]
-async-std = { version = "1.6.2", features = ["attributes"] }
+async-std = { version = "1.8.0", features = ["attributes"] }
 rand = {version = "0.7.3"}
 lazy_static = "1"
-tide = "0.13"
+tide = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = [
     "Yoshua Wuyts <yoshuawuyts@gmail.com>",
     "Irina Shestak <shestak.irina@gmail.com>",
     "Anton Whalley <anton@venshare.com>",
+    "Javier Viola <pepoviola@gmail.com>"
 ]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ mongodb = { version = "1.1.1", default-features = false, features = ["async-std-
 async-session = "2.0.0"
 async-trait = "0.1.36"
 serde_json = "1.0.56"
-chrono = "0.4.19"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/README.md
+++ b/README.md
@@ -48,29 +48,13 @@ $ cargo add async-mongodb-session
 
 ## Configuration
 
-This library utilises the document [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) in mongodb to expire the session.
+This library utilises the document [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) in mongodb to expire the session at the expiry
 
 The management of the expiry feature fits into the 12 factor [admin process definintion](https://12factor.net/admin-processes) so it's recommended to use an process outside of your web application to manage the expiry parameters.
 
-A `created` property is available on the root of the session document that so the [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) can be used in the configuration.
+A `expireAt` property is available on the root of the session document IFF the session expire is set. Note that  [async-session doesn't set by default](https://github.com/http-rs/async-session/blob/main/src/session.rs#L98).
 
-If your application code to create a session store is something like:
-```
-let store = MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "coll_session").await?;
-```
-
-Then the script to create the expiry would be:
-```
-use db_name;
-db.coll_session.createIndex( { created": 1 } , { expireAfterSeconds: 300 } ) 
-```
-
-If you wish to redefine the session duration then the index must be dropped first using:
-```
-use db_name;
-db.coll_session.dropIndex( { "created": 1 })
-db.coll_session.createIndex( { created": 1 } , { expireAfterSeconds: 300 } ) 
-```
+To enable this [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) at `index` for `expireAt` is created when the client `connet`. Allowing then to use this property from the session to set the expiration of the document.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@
 ```sh
 $ cargo add async-mongodb-session
 ```
+
+## Configuration
+
+This library utilises the document [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) in mongodb to expire the session.
+
+The management of the expiry feature fits into the 12 factor [admin process definintion](https://12factor.net/admin-processes) so it's recommended to use an process outside of your web application to manage the expiry parameters.
+
+A `created` property is available on the root of the session document that so the [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) can be used in the configuration.
+
+If your application code to create a session store is something like:
+```
+let store = MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "coll_session").await?;
+```
+
+Then the script to create the expiry would be:
+```
+use db_name;
+db.coll_session.createIndex( { created": 1 } , { expireAfterSeconds: 300 } ) 
+```
+
+If you wish to redefine the session duration then the index must be dropped first using:
+```
+use db_name;
+db.coll_session.dropIndex( { "created": 1 })
+db.coll_session.createIndex( { created": 1 } , { expireAfterSeconds: 300 } ) 
+```
+
 ## Test
 
 The tests rely on an running instance of mongodb either on your local machine or remote.

--- a/README.md
+++ b/README.md
@@ -56,16 +56,12 @@ Create an HTTP server that keep track of user visits in the session.
 
 ```rust
 #[async_std::main]
-async fn main() -> Result<(), std::io::Error> {
+async fn main() -> tide::Result<()> {
     tide::log::start();
     let mut app = tide::new();
 
-    let store = MongodbSessionStore::new("mongodb://127.0.0.1:27017", "db_name", "collection").await
-        .expect("Coldn't connect to the mongodb instance");
-    store.initialize().await.expect("Couldn't initialize the session store");
-
     app.with(tide::sessions::SessionMiddleware::new(
-        store,
+        MongodbSessionStore::new("mongodb://127.0.0.1:27017", "db_name", "collection").await?,
         std::env::var("TIDE_SECRET")
             .expect(
                 "Please provide a TIDE_SECRET value of at \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ cargo add async-mongodb-session
 
 ## Configuration
 
-This library utilises the document [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) in mongodb to expire the session at the expiry
+This library utilises the document [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) in mongodb to expire the session at the expiry.
 
 The management of the expiry feature fits into the 12 factor [admin process definintion](https://12factor.net/admin-processes) so it's recommended to use an process outside of your web application to manage the expiry parameters.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@
 $ cargo add async-mongodb-session
 ```
 
+## Overview
+This library allow you to utilises the document expiration feature based on a [specified number of seconds](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) or in a [specific clock time](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) supported by mongodb to expire the session.
+
+The management of the expiry feature fits into the 12 factor [admin process definintion](https://12factor.net/admin-processes) so it's recommended to use an process outside of your web application to manage the expiry parameters.
+
 ## Configuration
 
 A `created` property is available on the root of the session document that so the [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) can be used in the configuration.
@@ -68,11 +73,11 @@ db.coll_session.dropIndex( { "created": 1 })
 db.coll_session.createIndex( { "created": 1 } , { expireAfterSeconds: 300 } );
 ```
 
-Other way to set create the index is using  `create_created_index_for_global_expiry` passing the amount of seconds to expiry after the session.
+Other way to set create the index is using  `index_on_created` passing the amount of seconds to expiry after the session.
 
 Also, an `expireAt` property is available on the root of the session document IFF the session expire is set. Note that  [async-session doesn't set by default](https://github.com/http-rs/async-session/blob/main/src/session.rs#L98).
 
-To enable this [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) at `index` for `expireAt` should be created calling `create_expire_at_index` function or with this script ( following the above example )
+To enable this [expiry feature](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) at `index` for `expireAt` should be created calling `index_on_expiry_at` function or with this script ( following the above example )
 
 ```
 use db_name;

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ $ cargo add async-mongodb-session
 ## Overview
 This library allow you to utilises the document expiration feature based on a [specified number of seconds](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-after-a-specified-number-of-seconds) or in a [specific clock time](https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time) supported by mongodb to expire the session.
 
+The specified number of seconds approach is designed to enable the session time out to be managed at the mongodb layer. This approach provides a globally consistent session timeout across multiple processes but has the downside that all services using the same session collection must use the same timeout value.
+
+The specific clock time clock time approach is where you require more flexibility on your session timeouts such as a different session timeout per running service or you would prefer to manage the session time out at the process level. This is more flexible but might lead to some perceived inconsistency in session timeout depending on your upgrade/rollout strategy.
+
 The management of the expiry feature fits into the 12 factor [admin process definintion](https://12factor.net/admin-processes) so it's recommended to use an process outside of your web application to manage the expiry parameters.
 
 ## Configuration

--- a/examples/mongodb_session_store.rs
+++ b/examples/mongodb_session_store.rs
@@ -1,0 +1,47 @@
+extern crate async_mongodb_session;
+extern crate tide;
+
+use async_mongodb_session::MongodbSessionStore;
+
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    tide::log::start();
+    let mut app = tide::new();
+    let store =
+        MongodbSessionStore::new("mongodb://127.0.0.1:27017", "db_name", "collection").await?;
+    store.initialize().await?;
+
+    app.with(tide::sessions::SessionMiddleware::new(
+        store,
+        std::env::var("TIDE_SECRET")
+            .expect(
+                "Please provide a TIDE_SECRET value of at \
+                     least 32 bytes in order to run this example",
+            )
+            .as_bytes(),
+    ));
+
+    app.with(tide::utils::Before(
+        |mut request: tide::Request<()>| async move {
+            let session = request.session_mut();
+            let visits: usize = session.get("visits").unwrap_or_default();
+            session.insert("visits", visits + 1).unwrap();
+            request
+        },
+    ));
+
+    app.at("/").get(|req: tide::Request<()>| async move {
+        let visits: usize = req.session().get("visits").unwrap();
+        Ok(format!("you have visited this website {} times", visits))
+    });
+
+    app.at("/reset")
+        .get(|mut req: tide::Request<()>| async move {
+            req.session_mut().destroy();
+            Ok(tide::Redirect::new("/"))
+        });
+
+    app.listen("127.0.0.1:8080").await?;
+
+    Ok(())
+}

--- a/examples/mongodb_session_store.rs
+++ b/examples/mongodb_session_store.rs
@@ -7,12 +7,9 @@ use async_mongodb_session::MongodbSessionStore;
 async fn main() -> tide::Result<()> {
     tide::log::start();
     let mut app = tide::new();
-    let store =
-        MongodbSessionStore::new("mongodb://127.0.0.1:27017", "db_name", "collection").await?;
-    store.initialize().await?;
 
     app.with(tide::sessions::SessionMiddleware::new(
-        store,
+        MongodbSessionStore::new("mongodb://127.0.0.1:27017", "db_name", "collection").await?,
         std::env::var("TIDE_SECRET")
             .expect(
                 "Please provide a TIDE_SECRET value of at \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,11 @@ impl MongodbSessionStore {
     /// .await?;
     /// # Ok(()) }) }
     /// ```
-    pub async fn new(uri: &str, db: &str, coll_name: &str) -> Result<Self> { //mongodb::error::Result<Self> {
-        let client = Client::with_uri_str(uri).await.map_err(|e | { std::io::Error::new( std::io::ErrorKind::Other, e.labels().join(" ") ) })?;
+    pub async fn new(uri: &str, db: &str, coll_name: &str) -> Result<Self> {
+        //mongodb::error::Result<Self> {
+        let client = Client::with_uri_str(uri)
+            .await
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.labels().join(" ")))?;
         let middleware = Self::from_client(client, db, coll_name);
         middleware.index_on_expiry_at().await?;
         Ok(middleware)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,7 @@ impl MongodbSessionStore {
     /// store.index_on_created(300).await?;
     /// # Ok(()) }) }
     /// ```
-    pub async fn index_on_created(
-        &self,
-        expire_after_seconds: u32,
-    ) -> Result {
+    pub async fn index_on_created(&self, expire_after_seconds: u32) -> Result {
         let create_index = doc! {
             "createIndexes": &self.coll_name,
             "indexes": [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use async_session::{Result, Session, SessionStore};
 use async_trait::async_trait;
 use mongodb::bson;
 use mongodb::bson::doc;
-use mongodb::options::{ReplaceOptions,SelectionCriteria};
+use mongodb::options::{ReplaceOptions, SelectionCriteria};
 use mongodb::Client;
 
 /// A MongoDB session store.
@@ -53,7 +53,13 @@ impl MongodbSessionStore {
                 }
             ]
         };
-        client.database(db).run_command(create_index, SelectionCriteria::ReadPreference( mongodb::options::ReadPreference::Primary)).await?;
+        client
+            .database(db)
+            .run_command(
+                create_index,
+                SelectionCriteria::ReadPreference(mongodb::options::ReadPreference::Primary),
+            )
+            .await?;
         Ok(Self::from_client(client, db, coll_name))
     }
 
@@ -94,8 +100,12 @@ impl SessionStore for MongodbSessionStore {
         let id = session.id();
         let query = doc! { "session_id": id };
         let replacement = match session.expiry() {
-            None => { doc! { "session_id": id, "session": value,"created": Utc::now() } },
-            Some( expire_at ) => { doc! { "session_id": id, "session": value, "expireAt": expire_at, "created": Utc::now() } }
+            None => {
+                doc! { "session_id": id, "session": value,"created": Utc::now() }
+            }
+            Some(expire_at) => {
+                doc! { "session_id": id, "session": value, "expireAt": expire_at, "created": Utc::now() }
+            }
         };
 
         let opts = ReplaceOptions::builder().upsert(true).build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl MongodbSessionStore {
     /// that mongodb provides https://docs.mongodb.com/manual/tutorial/expire-data/#expire-documents-at-a-specific-clock-time.
     /// The default ttl applyed to sessions without expiry is 20 minutes.
     /// If the `expireAt` date field contains a date in the past, mongodb considers the document expired and will be deleted.
-    /// Note: mongodb runs the expiration logic every 60 seconds.    
+    /// Note: mongodb runs the expiration logic every 60 seconds.
     /// ```rust
     /// # fn main() -> async_session::Result { async_std::task::block_on(async {
     /// # use async_mongodb_session::MongodbSessionStore;
@@ -103,7 +103,7 @@ impl MongodbSessionStore {
     /// .await?;
     /// let ttl = store.ttl();
     /// # Ok(()) }) }
-    /// ```    
+    /// ```
     pub fn ttl(&self) -> usize {
         self.ttl
     }
@@ -117,7 +117,7 @@ impl MongodbSessionStore {
     /// .await?;
     /// store.set_ttl(300);
     /// # Ok(()) }) }
-    /// ```    
+    /// ```
     pub fn set_ttl(&mut self, ttl: usize) {
         self.ttl = ttl;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ impl SessionStore for MongodbSessionStore {
             Some(doc) => {
                 let bsession = match doc.get("session") {
                     Some(v) => v.clone(),
-                    None => bson::to_bson::<Session>(&Session::new()).unwrap(),
+                    None => return Ok(None),
                 };
                 Ok(Some(bson::from_bson::<Session>(bsession)?))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,10 @@ impl MongodbSessionStore {
     /// let store =
     /// MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "collection")
     /// .await?;
-    /// store.create_created_index_for_global_expiry(300).await?;
+    /// store.index_on_created(300).await?;
     /// # Ok(()) }) }
     /// ```
-    pub async fn create_created_index_for_global_expiry(
+    pub async fn index_on_created(
         &self,
         expire_after_seconds: u32,
     ) -> Result {
@@ -119,10 +119,10 @@ impl MongodbSessionStore {
     /// let store =
     /// MongodbSessionStore::connect("mongodb://127.0.0.1:27017", "db_name", "collection")
     /// .await?;
-    /// store.create_expire_at_index().await?;
+    /// store.index_on_expiry_at().await?;
     /// # Ok(()) }) }
     /// ```
-    pub async fn create_expire_at_index(&self) -> Result {
+    pub async fn index_on_expiry_at(&self) -> Result {
         let create_index = doc! {
             "createIndexes": &self.coll_name,
             "indexes": [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,11 @@ impl MongodbSessionStore {
     /// .await?;
     /// # Ok(()) }) }
     /// ```
-    pub async fn new(uri: &str, db: &str, coll_name: &str) -> mongodb::error::Result<Self> {
-        let client = Client::with_uri_str(uri).await?;
-        Ok(Self::from_client(client, db, coll_name))
+    pub async fn new(uri: &str, db: &str, coll_name: &str) -> Result<Self> { //mongodb::error::Result<Self> {
+        let client = Client::with_uri_str(uri).await.map_err(|e | { std::io::Error::new( std::io::ErrorKind::Other, e.labels().join(" ") ) })?;
+        let middleware = Self::from_client(client, db, coll_name);
+        middleware.index_on_expiry_at().await?;
+        Ok(middleware)
     }
 
     /// Create a new instance of `MongodbSessionStore` from an open client.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 
-use async_session::chrono::{Utc, Duration};
+use async_session::chrono::{Duration, Utc};
 use async_session::{Result, Session, SessionStore};
 use async_trait::async_trait;
 use mongodb::bson;
@@ -117,7 +117,8 @@ impl MongodbSessionStore {
     /// # Ok(()) }) }
     /// ```
     pub async fn index_on_created(&self, expire_after_seconds: u32) -> Result {
-        self.create_expire_index("created", expire_after_seconds).await?;
+        self.create_expire_index("created", expire_after_seconds)
+            .await?;
         Ok(())
     }
 
@@ -148,9 +149,9 @@ impl SessionStore for MongodbSessionStore {
         let id = session.id();
         let query = doc! { "session_id": id };
         let expire_at = match session.expiry() {
-            None => { Utc::now() + Duration::from_std(std::time::Duration::from_secs(1220)).unwrap() },
+            None => Utc::now() + Duration::from_std(std::time::Duration::from_secs(1200)).unwrap(),
 
-            Some(expiry) =>  *{ expiry }
+            Some(expiry) => *{ expiry },
         };
         let replacement = doc! { "session_id": id, "session": value, "expireAt": expire_at, "created": Utc::now() };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -44,10 +44,10 @@ mod tests {
     }
 
     #[test]
-    fn test_connect() -> async_session::Result {
+    fn test_new() -> async_session::Result {
         async_std::task::block_on(async {
             let store =
-                MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
+                MongodbSessionStore::new(&CONNECTION_STRING, "db_name", "collection").await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();
@@ -68,7 +68,7 @@ mod tests {
     fn test_with_expire() -> async_session::Result {
         async_std::task::block_on(async {
             let store =
-                MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
+                MongodbSessionStore::new(&CONNECTION_STRING, "db_name", "collection").await?;
 
             store.initialize().await?;
 
@@ -94,7 +94,7 @@ mod tests {
         use std::time::Duration;
         async_std::task::block_on(async {
             let store =
-                MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
+                MongodbSessionStore::new(&CONNECTION_STRING, "db_name", "collection").await?;
 
             store.initialize().await?;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -88,8 +88,8 @@ mod tests {
 
     #[test]
     fn test_check_expired() -> async_session::Result {
-        use std::time::Duration;
         use async_std::task;
+        use std::time::Duration;
         async_std::task::block_on(async {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -70,7 +70,7 @@ mod tests {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
 
-            store.index_on_expiry_at().await?;
+            store.initialize().await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();
@@ -96,7 +96,7 @@ mod tests {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
 
-            store.index_on_expiry_at().await?;
+            store.initialize().await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -70,7 +70,7 @@ mod tests {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
 
-            store.create_expire_at_index().await?;
+            store.index_on_expiry_at().await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();
@@ -96,7 +96,7 @@ mod tests {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
 
-            store.create_expire_at_index().await?;
+            store.index_on_expiry_at().await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -70,6 +70,8 @@ mod tests {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
 
+            store.create_expire_at_index().await?;
+
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();
             let key = format!("key-{}", n2);
@@ -93,6 +95,8 @@ mod tests {
         async_std::task::block_on(async {
             let store =
                 MongodbSessionStore::connect(&CONNECTION_STRING, "db_name", "collection").await?;
+
+            store.create_expire_at_index().await?;
 
             let mut rng = rand::thread_rng();
             let n2: u16 = rng.gen();


### PR DESCRIPTION
This patch fixes #6 and also exposes a datetime property named `created` at the root level of the session document as using the expiry property inside the session store object gives this error.
```
db.collection.createIndex( { "session" : { "expiry": 1 } }, { expireAfterSeconds: 3600 } ) 
{
	"ok" : 0,
	"errmsg" : "Values in v:2 index key pattern cannot be of type object. Only numbers > 0, numbers < 0, and strings are allowed.",
	"code" : 67,
	"codeName" : "CannotCreateIndex"
}
```

It also provides instructions on how to configure mongo to expire the session.