### PR TITLE
Use async-session reexports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ authors = [
 [dependencies]
 mongodb = { version = "1.1.1", default-features = false, features = ["async-std-runtime"] }
 async-session = "2.0.0"
-async-trait = "0.1.36"
-serde_json = "1.0.56"
 
 [dev-dependencies]
 async-std = { version = "1.6.2", features = ["attributes"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
 
-use async_session::{Result, Session, SessionStore};
-use async_trait::async_trait;
+use async_session::{async_trait, serde_json, Result, Session, SessionStore};
 use mongodb::bson::doc;
 use mongodb::options::ReplaceOptions;
 use mongodb::Client;


### PR DESCRIPTION
I was looking at #9 by @No9 (which is an excellent numbering coincidence) and noticed that async-mongodb-session doesn't use some of the reexports from async-session