### PR TITLE
removed createdby attributes and enforced expiry time

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -108,9 +108,7 @@ mod tests {
 
             let cookie_value = store.store_session(session).await?.unwrap();
 
-            // mongodb runs the background task that removes expired documents runs every 60 seconds.
-            // https://docs.mongodb.com/manual/core/index-ttl/#timing-of-the-delete-operation
-            task::sleep(Duration::from_secs(60)).await;
+            task::sleep(Duration::from_secs(1)).await;
             let session_to_recover = store.load_session(cookie_value).await?;
 
             assert!(&session_to_recover.is_none());


### PR DESCRIPTION
This PR removes the feature to expire sessions based on the created_time plus interval.
The feature was designed to enable the duration of a session to be controlled by database configuration rather than potentially each application instance.
While created_time plus interval is a valid use case as it ensures that all instances of an application service have the same session duration the complexity of mixing the functionality with the default application level expiry_at functionality was error prone due to the index management required and added a great deal of complexity to the API in this library.
Specifically:
This library now creates an index on the expiry_at automatically in order to improve developer experience. If we want to apply a different index to support created_time then we have to remove the expiry_at index and ensure it isn't reapplied.
This would mean that DX would suffer as some iniitalise semantics would be mandatory.

If there is interest in this feature in the future I would recommend implementing it as a separate session store type rather than including it in MongodbSessionStore.

I've also put in a conditional on expiry_at  so that expired sessions that haven't been sweeped wouldn't be returned.

@pepoviola Thanks for trying to facilitate the feature but I think sticking with your main implementation makes sense right now.
If you're OK with it I will merge this in.